### PR TITLE
Add "Hide Ground Overlay" player vision suboption

### DIFF
--- a/scripts/devtools/submenus/playervision.lua
+++ b/scripts/devtools/submenus/playervision.lua
@@ -44,6 +44,18 @@ return {
         },
         { type = MOD_DEV_TOOLS.OPTION.DIVIDER },
         {
+            type = MOD_DEV_TOOLS.OPTION.ACTION,
+            options = {
+                label = "Hide Ground Overlay",
+                on_accept_fn = function()
+                    for i = 0, 2 do
+                        TheWorld.Map["SetOverlayColor" .. i](TheWorld.Map, 0, 0, 0, 0)
+                    end
+                end,
+            },
+        },
+        { type = MOD_DEV_TOOLS.OPTION.DIVIDER },
+        {
             type = MOD_DEV_TOOLS.OPTION.CHOICES,
             options = {
                 label = "CCT",


### PR DESCRIPTION
A simple solution to the "Toggle Snow Visibility" issue (fixes partly #4), allowing to remove ground moisture/snow.

Adding that toggle feature could require metatables tracking world weather component, or make it incompatible with weather component changes.